### PR TITLE
Adding star counts to project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,8 @@
                     <div class="project-logo">
                         <img src="static/img/yarn.png">
                     </div>
-                    <h3 class="project-title">Yarn Version Manager</h3>
+                    <h3 class="project-title">Yarn Version Manager </h3>
+                    <div class="project-stars" data-project="yvm"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                         YVM is a tool that allows you to manage multiple versions of
                         Yarn, which is especially useful when working with many projects that
@@ -69,6 +70,7 @@
                         <img src="static/img/jenkins.png">
                     </div>
                     <h3 class="project-title">Jenkins TL</h3>
+                    <div class="project-stars" data-project="jenkins-timeline-plugin"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                         Jenkins Timeline is a Jenkins plugin that allows users to gain knowledge
                         about the execution of their builds
@@ -84,6 +86,7 @@
                         <img src="static/img/ml.png">
                     </div>
                     <h3 class="project-title">with-immutable-props-to-js</h3>
+                    <div class="project-stars" data-project="with-immutable-props-to-js"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                     A higher-order component for keeping Immutable objects outside of your presentational components
                     </p>
@@ -98,6 +101,7 @@
                         <img src="static/img/rtv.png">
                     </div>
                     <h3 class="project-title">RichTextView</h3>
+                    <div class="project-stars" data-project="RichTextView"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                     iOS Text View (UIView) that properly displays LaTeX, HTML, Markdown, YouTube and Vimeo links
                     </p>
@@ -112,6 +116,7 @@
                         <img src="static/img/runner.png">
                     </div>
                     <h3 class="project-title">Sanity Runner</h3>
+                    <div class="project-stars" data-project="sanity-runner"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                     Automate your sanity tests against a Chrome browser running in AWS Lambda
                     </p>
@@ -126,6 +131,7 @@
                         <img src="static/img/codewatch.png">
                     </div>
                     <h3 class="project-title">Codewatch</h3>
+                    <div class="project-stars" data-project="codewatch"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                     Add highly customizable assertions and/or metrics based on your codebases's AST (Abstract Syntax Tree)
                     </p>
@@ -140,6 +146,7 @@
                         <img src="static/img/monodeploy.svg">
                     </div>
                     <h3 class="project-title">monodeploy</h3>
+                    <div class="project-stars" data-project="monodeploy"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                         A small wrapper around lerna that makes it easier to use in CI
                     </p>
@@ -154,6 +161,7 @@
                         <img src="static/img/commit-utils.svg">
                     </div>
                     <h3 class="project-title">Commit Utils</h3>
+                    <div class="project-stars" data-project="commit-utils"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                         Top Hat's commitlint config, including a commitizen adapter and conventional changelog preset
                     </p>
@@ -168,6 +176,7 @@
                         <img src="static/img/commit-watch.png">
                     </div>
                     <h3 class="project-title">commit-watch</h3>
+                    <div class="project-stars" data-project="commit-watch"><i class="fas fa-star"></i><span class="count"></span></div>
                     <p class="project-description">
                         Ensure your commit messages are formatted based on your commitlint config
                     </p>
@@ -257,6 +266,7 @@
         </section>
     </body>
     <script src="static/js/slack.js"></script>
+    <script src="static/js/stars.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-129741728-1"></script>
     <script>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -85,7 +85,6 @@ section {
     background-color: #fff;
     border-radius: 2px;
     box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.12), 0 1px 4px 0 rgba(0, 0, 0, 0.12);
-    height: 280px;
     padding: 40px;
     width: 293px;
     margin-bottom: 30px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -113,6 +113,10 @@ section {
     opacity: 0;
 }
 
+.project-stars > .fas {
+    margin-right: 5px;
+}
+
 .pink.link {
     color: #e5166b;
     text-decoration: none;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -108,6 +108,11 @@ section {
     float: right;
 }
 
+.project-stars {
+    transition: 0.5s;
+    opacity: 0;
+}
+
 .pink.link {
     color: #e5166b;
     text-decoration: none;

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -1,0 +1,35 @@
+function fetchRepoDataBlob() {
+    const endpoint = 'https://api.github.com/orgs/tophat/repos'
+    let http = new XMLHttpRequest()
+    http.open('GET', endpoint, true)
+    http.onreadystatechange = function() {
+        if (http.readyState === 4) {
+            const responseData = JSON.parse(http.response)
+            const starCount = gatherStargazerData(responseData)
+            insertStargazerBadges(starCount)
+        }
+    }
+    http.send()
+}
+
+function gatherStargazerData(response) {
+    return response.reduce(function (acc, project) {
+        const { name, stargazers_count: stars } = project
+        acc[name] = stars
+        return acc
+    }, {})
+}
+
+function insertStargazerBadges(starCounts) {
+    Object.entries(starCounts).forEach(function([project, item]) {
+        const badge = document.querySelector(".project-stars[data-project='" + project +"']")
+
+        if (badge) {
+            const count = badge.querySelector('.count')
+            count.innerText = item
+            badge.style.opacity = 1
+        }
+    })
+}
+
+fetchRepoDataBlob()


### PR DESCRIPTION
The title says it all: this adds an extra smidge of Javascript to pull the stargazer counts off the Github API and insert them underneath the respective projects' names.

This addresses #59.