### PR TITLE
Better use of gazers stats on project cards

### DIFF
--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -57,7 +57,7 @@ function insertStargazerBadges(starCounts) {
 }
 
 function disableStargazerBadges() {
-   Array(...document.getElementsByClassName('project-stars')).forEach(item => { item.remove() })
+   [...document.getElementsByClassName('project-stars')].forEach(item => item.remove())
 }
 
 fetchRepoDataBlob()

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -46,7 +46,6 @@ function gatherStargazerData(response) {
 function insertStargazerBadges(starCounts) {
     starCounts.forEach(function([project, item], index) {
         const badge = document.querySelector(".project-stars[data-project='" + project +"']")
-       
         if (badge) {
             const projectBox = badge.parentNode
             const count = badge.querySelector('.count')

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -12,22 +12,36 @@ function fetchRepoDataBlob() {
     http.send()
 }
 
+function _sortByStarCount(gazers) {
+    return Object.entries(gazers).sort(function(first, second) {
+        const firstCount = first[1]
+        const secondCount = second[1]
+
+        if (firstCount < secondCount) return -1
+        else if (firstCount > secondCount) return 1
+        else return 0
+    })
+}
+
 function gatherStargazerData(response) {
-    return response.reduce(function (acc, project) {
+    const gazers = response.reduce(function (acc, project) {
         const { name, stargazers_count: stars } = project
         acc[name] = stars
         return acc
     }, {})
+    return _sortByStarCount(gazers)
 }
 
 function insertStargazerBadges(starCounts) {
-    Object.entries(starCounts).forEach(function([project, item]) {
+    starCounts.forEach(function([project, item], index) {
         const badge = document.querySelector(".project-stars[data-project='" + project +"']")
-
+       
         if (badge) {
+            const projectBox = badge.parentNode
             const count = badge.querySelector('.count')
             count.innerText = item
             badge.style.opacity = 1
+            projectBox.style.order = index
         }
     })
 }

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -3,10 +3,15 @@ function fetchRepoDataBlob() {
     let http = new XMLHttpRequest()
     http.open('GET', endpoint, true)
     http.onreadystatechange = function() {
-        if (http.readyState === 4) {
+        if (http.readyState !== 4) return
+
+        if (http.status === 200 && http.response) {
             const responseData = JSON.parse(http.response)
             const starCount = gatherStargazerData(responseData)
+            console.log(starCount)
             insertStargazerBadges(starCount)
+        } else {
+            disableStargazerBadges()
         }
     }
     http.send()
@@ -14,22 +19,29 @@ function fetchRepoDataBlob() {
 
 function _sortByStarCount(gazers) {
     return Object.entries(gazers).sort(function(first, second) {
-        const firstCount = first[1]
-        const secondCount = second[1]
+        const firstCount = first[1].stars
+        const secondCount = second[1].stars
+        return firstCount - secondCount
+    })
+}
 
-        if (firstCount < secondCount) return -1
-        else if (firstCount > secondCount) return 1
+function _sortByLastPush(gazers) {
+    return Object.entries(gazers).sort(function(first, second) {
+        const firstActive = new Date(first[1].active)
+        const secondActive = new Date(second[1].active)
+        if (firstActive < secondActive) return -1
+        else if (firstActive > secondActive) return 1
         else return 0
     })
 }
 
 function gatherStargazerData(response) {
     const gazers = response.reduce(function (acc, project) {
-        const { name, stargazers_count: stars } = project
-        acc[name] = stars
+        const { name, stargazers_count: stars, pushed_at:active } = project
+        acc[name] = { stars, active }
         return acc
     }, {})
-    return _sortByStarCount(gazers)
+    return _sortByLastPush(gazers)
 }
 
 function insertStargazerBadges(starCounts) {
@@ -39,11 +51,15 @@ function insertStargazerBadges(starCounts) {
         if (badge) {
             const projectBox = badge.parentNode
             const count = badge.querySelector('.count')
-            count.innerText = item
+            count.innerText = item.stars
             badge.style.opacity = 1
             projectBox.style.order = index
         }
     })
+}
+
+function disableStargazerBadges() {
+   Array(...document.getElementsByClassName('project-stars')).forEach(item => { item.remove() })
 }
 
 fetchRepoDataBlob()

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -45,7 +45,7 @@ function gatherStargazerData(response) {
 
 function insertStargazerBadges(starCounts) {
     starCounts.forEach(function([project, item], index) {
-        const badge = document.querySelector(".project-stars[data-project='" + project +"']")
+         const badge = document.querySelector(`.project-stars[data-project='${project}']`)
         if (badge) {
             const projectBox = badge.parentNode
             const count = badge.querySelector('.count')

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -8,7 +8,6 @@ function fetchRepoDataBlob() {
         if (http.status === 200 && http.response) {
             const responseData = JSON.parse(http.response)
             const starCount = gatherStargazerData(responseData)
-            console.log(starCount)
             insertStargazerBadges(starCount)
         } else {
             disableStargazerBadges()
@@ -29,8 +28,8 @@ function _sortByLastPush(gazers) {
     return Object.entries(gazers).sort(function(first, second) {
         const firstActive = new Date(first[1].active)
         const secondActive = new Date(second[1].active)
-        if (firstActive < secondActive) return -1
-        else if (firstActive > secondActive) return 1
+        if (firstActive < secondActive) return 1
+        else if (firstActive > secondActive) return -1
         else return 0
     })
 }


### PR DESCRIPTION
This PR adds a graceful failure path to the request to get repo info; in the case of a 403 (rate-limited), the badges are simply disabled. Otherwise, you can sort by `pushed_at`, which represents the time of the last push.

## QA

If you use `http-server` locally, feel free to `http-server` and visit the site, then verify that the order in which the items appear corresponds to the order in which the repos appear on Github. They are now ordered by last activity.

There are plans to add some sort of toggle since there is also logic to sort by stars.

In the network tab, block the Github API request domain, reload the page, ensure that the page fails gracefully. This is what will happen if the user is rate-limited.