### PR TITLE
fix: Improve site accessibility

### DIFF
--- a/_data/social_media_links.yml
+++ b/_data/social_media_links.yml
@@ -1,11 +1,15 @@
 - link: https://www.github.com/tophat
   fa_icon: fa-github-alt
+  name: GitHub
 
 - link: https://www.medium.com/top-hat-engineering
   fa_icon: fa-medium-m
+  name: Medium
 
 - link: https://www.twitter.com/tophat
   fa_icon: fa-twitter
+  name: Twitter
 
 - link: https://www.facebook.com/TopHatHQ
   fa_icon: fa-facebook-f
+  name: Facebook

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="links">
             {% for social_media_link in site.data.social_media_links %}
-                <a href="{{ social_media_link.link }}">
+                <a href="{{ social_media_link.link }}" aria-label="{{ social_media_link.name }}">
                 <span class="fa-stack fa-sm">
                     <i class="fa fa-circle fa-stack-2x"></i>
                     <i class="fab {{ social_media_link.fa_icon }} fa-stack-1x fa-inverse"></i>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<section class="footer">
+<section class="footer" role="region" aria-label="Social Media">
     <div class="container">
         <div class="links">
             {% for social_media_link in site.data.social_media_links %}

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,16 +1,16 @@
-<section class="hero">
+<section class="hero" role="banner">
     <div class="stripe-bg"></div>
     <div class="header">
         <div class="logo">
-            <a href="https://www.tophat.com/"><img class="tophat-logo" src="static/img/tophat-logo-white.svg"></a>
+            <a href="https://www.tophat.com/" aria-label="Top Hat Homepage"><img class="tophat-logo" src="static/img/tophat-logo-white.svg" role="none"></a>
             <div class="logo-divider"></div>
             {% if page.id == 'index' %}
-            <img class="open-source-logo" src="static/img/open-source-logo-all-white.svg">
+            <img class="open-source-logo" src="static/img/open-source-logo-all-white.svg" role="none">
             {% else %}
-            <a href="/"><img class="open-source-logo" src="../static/img/open-source-logo-all-white.svg"></a>
+            <a href="/"><img class="open-source-logo" src="../static/img/open-source-logo-all-white.svg" role="none"></a>
             {% endif %}
         </div>
-        <div class="navigation">
+        <div class="navigation" role="navigation">
             {% for link in site.data.header_navigation_links %}
                 <span><a href="{{ link.link }}">{{ link.text }}</a></span>
             {% endfor %}

--- a/_includes/join.html
+++ b/_includes/join.html
@@ -1,4 +1,4 @@
-<section class="join">
+<section class="join" role="region" aria-labelledby="get-involved">
     <div class="container">
 
         <h1 class="section-title" id="get-involved">Get Involved</h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
     {% include head.html %}
 

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@ id: index
         {% for project in site.data.projects %}
             <div class="project-card">
                 <div class="project-logo">
-                    <img src="{{ project.img_src }}">
+                    <img src="{{ project.img_src }}" role="none">
                 </div>
-                <h3 class="project-title">{{ project.title }}</h3>
+                <h2 class="project-title">{{ project.title }}</h3>
                 <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star"></i><span class="count"></span></div>
                 <p class="project-description">
                     {{ project.description }}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ id: index
                     <img src="{{ project.img_src }}" role="none">
                 </div>
                 <h2 class="project-title">{{ project.title }}</h2>
-                <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star"></i><span class="count" aria-label="Project stars"></span></div>
+                <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star" role="none"></i><span class="count" role="text"></span></div>
                 <p class="project-description">
                     {{ project.description }}
                 </p>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@ layout: default
 id: index
 ---
 
-<section class="explore">
+<section class="explore" role="main" aria-labelledby="explore-projects">
     <div class="container">
-    <h1 class="section-title">Explore Projects</h1>
+    <h1 id="explore-projects" class="section-title">Explore Projects</h1>
     <div id="projects">
         {% for project in site.data.projects %}
             <div class="project-card">
                 <div class="project-logo">
                     <img src="{{ project.img_src }}" role="none">
                 </div>
-                <h2 class="project-title">{{ project.title }}</h3>
-                <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star"></i><span class="count"></span></div>
+                <h2 class="project-title">{{ project.title }}</h2>
+                <div class="project-stars" data-project="{{ project.data_project }}" aria-label="Project stars"><i class="fas fa-star"></i><span class="count"></span></div>
                 <p class="project-description">
                     {{ project.description }}
                 </p>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@ id: index
                     <img src="{{ project.img_src }}" role="none">
                 </div>
                 <h2 class="project-title">{{ project.title }}</h2>
-                <div class="project-stars" data-project="{{ project.data_project }}" aria-label="Project stars"><i class="fas fa-star"></i><span class="count"></span></div>
+                <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star"></i><span class="count" aria-label="Project stars"></span></div>
                 <p class="project-description">
                     {{ project.description }}
                 </p>
                 <p class="project-links">
                     {% for link in project.links %}
-                        <a class="pink link" href="{{ link.link }}">{{ link.text }}</a>
+                        <a class="pink link" href="{{ link.link }}" aria-label="{{ project.title }} {{ link.text }}">{{ link.text }}</a>
                     {% endfor %}
                 </p>
             </div>

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -50,6 +50,7 @@ function insertStargazerBadges(starCounts) {
             const projectBox = badge.parentNode
             const count = badge.querySelector('.count')
             count.innerText = item.stars
+            count.ariaLabel = `${item.stars} stars`
             badge.style.opacity = 1
             projectBox.style.order = index
         }


### PR DESCRIPTION
https://github.com/tophat/opensource.tophat.com/issues/63

Fixes:
- Social media links should have text
- Presentational icons and images did not have an alt-text or marked as presentational
- Add landmarks: banner, navigation, main, social media
- "Website" and "GitHub" links on each project provides more context on where the link will go
- Screenreader provides more context on the project stars instead of simply reading the number

Outstanding issues (TODO, as followup):
- Nice to have: skip to main content button?
- The projects list has a super strange order on the screenreader
- Verify colour contrast is within standards

## AuthorQA
- ✅ Verify you can navigate via landmarks
- ✅ Verify no axe a11y violations greater than moderate severity
- ✅ Verify screenreader says "x stars" when viewing a project
- ✅ Verify screenreader gives context on social media buttons at the bottom 

<img width="734" alt="Screen Shot 2020-12-17 at 11 10 00 AM" src="https://user-images.githubusercontent.com/36058447/102512796-70480580-4058-11eb-936c-1f787e1db0fd.png">
