### PR TITLE
fix: Put projects in the correct DOM order

### DIFF
--- a/_includes/join.html
+++ b/_includes/join.html
@@ -12,7 +12,7 @@
                     We’re looking for people who are as excited as we are to help build a teaching platform that transforms the way learning is delivered at universities and colleges across the globe.
                     </p>
                 </div>
-                <a href="https://www.tophat.com/company/work-with-us#engineering"><button class="button pink">View Our Open Positions</button></a>
+                <a href="https://www.tophat.com/company/work-with-us#engineering"><button class="button pink" tabindex="-1">View Our Open Positions</button></a>
             </div>
 
             {% comment %}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ id: index
     <h1 class="section-title">Explore Projects</h1>
     <div id="projects">
         {% for project in site.data.projects %}
-            <div class="project-card">
+            <div class="project-card" id="{{ project.data_project }}">
                 <div class="project-logo">
                     <img src="{{ project.img_src }}">
                 </div>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ id: index
                     <img src="{{ project.img_src }}" role="none">
                 </div>
                 <h2 class="project-title">{{ project.title }}</h2>
-                <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star" role="none"></i><span class="count" role="text"></span></div>
+                <div class="project-stars" data-project="{{ project.data_project }}"><i class="fas fa-star"></i><span class="count"></span></div>
                 <p class="project-description">
                     {{ project.description }}
                 </p>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -17,6 +17,16 @@ h3 {
 h2 {
     font-weight: 500;
 }
+.project-title {
+    /* h3 styling */
+    display: block;
+    font-size: 1.17em;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+}
+
 p {
     font-family: 'October 3';
     font-weight: 300;

--- a/static/js/slack.js
+++ b/static/js/slack.js
@@ -95,5 +95,9 @@ const handleFormSubmit = (e) => {
 
 const form = document.getElementById('slack-invite')
 const submitButton = document.getElementById('slack-submit-button')
-form.addEventListener('submit', handleFormSubmit)
-submitButton.addEventListener('click', handleFormSubmit)
+if (form) {
+    form.addEventListener('submit', handleFormSubmit)
+}
+if (submitButton) {
+    submitButton.addEventListener('click', handleFormSubmit)
+}

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -8,7 +8,8 @@ function fetchRepoDataBlob() {
         if (http.status === 200 && http.response) {
             const responseData = JSON.parse(http.response)
             const starCount = gatherStargazerData(responseData)
-            insertStargazerBadges(starCount)
+            const starCountSortedDesc = _sortByStarCount(starCount)
+            insertStargazerBadges(starCountSortedDesc)
         } else {
             disableStargazerBadges()
         }
@@ -17,10 +18,10 @@ function fetchRepoDataBlob() {
 }
 
 function _sortByStarCount(gazers) {
-    return Object.entries(gazers).sort(function(first, second) {
+    return gazers.sort(function(first, second) {
         const firstCount = first[1].stars
         const secondCount = second[1].stars
-        return firstCount - secondCount
+        return secondCount - firstCount
     })
 }
 
@@ -44,14 +45,18 @@ function gatherStargazerData(response) {
 }
 
 function insertStargazerBadges(starCounts) {
+    const projectContainerElement = document.querySelector('#projects')
     starCounts.forEach(function([project, item], index) {
-         const badge = document.querySelector(`.project-stars[data-project='${project}']`)
+        const projectElement = document.querySelector(`#${project}`)
+        if (projectElement) {
+            projectContainerElement.appendChild(projectElement)
+        }
+        const badge = document.querySelector(`.project-stars[data-project='${project}']`)
         if (badge) {
             const projectBox = badge.parentNode
             const count = badge.querySelector('.count')
             count.innerText = item.stars
             badge.style.opacity = 1
-            projectBox.style.order = index
         }
     })
 }


### PR DESCRIPTION
Previously, the order of the projects was simply the order GitHub's `repo` API call would return. There was some code that sorted based on stars that wasn't being used. 

This PR updates the code to use the sorting logic, as well as placing the projects in the correct order in the DOM so that keyboard navigators don't get super confused

Related issues: https://github.com/tophat/opensource.tophat.com/issues/63

## AuthorQA
- ✅ Verify projects are sorted by stars, descending
- ✅ Verify tab order is correct; ✅ verify screenreader navigation is correct

## Screenshots
<img width="623" alt="Screen Shot 2020-12-17 at 12 19 51 PM" src="https://user-images.githubusercontent.com/36058447/102521005-5b706f80-4062-11eb-8592-316190a63c12.png">
