### PR TITLE
fix: Make project list more semantic

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@ id: index
 <section class="explore" role="main" aria-labelledby="explore-projects">
     <div class="container">
     <h1 id="explore-projects" class="section-title">Explore Projects</h1>
-    <div id="projects">
+    <ul id="projects">
         {% for project in site.data.projects %}
-            <div class="project-card" id="{{ project.data_project }}">
+            <li class="project-card" id="{{ project.data_project }}">
                 <div class="project-logo">
                     <img src="{{ project.img_src }}" role="none">
                 </div>
@@ -22,9 +22,9 @@ id: index
                         <a class="pink link" href="{{ link.link }}" aria-label="{{ project.title }} {{ link.text }}">{{ link.text }}</a>
                     {% endfor %}
                 </p>
-            </div>
+            </li>
         {% endfor %}
-    </div>
+    </ul>
     </div>
 </section>
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -108,6 +108,7 @@ section {
     flex-wrap: wrap;
     justify-content: space-around;
     list-style: none;
+    padding-inline: 0;
 }
 .project-description {
     font-size: 16px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -107,6 +107,7 @@ section {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-around;
+    list-style: none;
 }
 .project-description {
     font-size: 16px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -195,6 +195,10 @@ section {
     margin-left: 20px;
 }
 
+.logo {
+    display: flex;
+}
+
 .header .logo .tophat-logo {
     width: 139px;
     height: 19px;
@@ -220,7 +224,7 @@ section {
 }
 
 @media (max-width: 650px) {
-    .logo { margin-left: 15px; }
+    .logo { margin-left: 15px; display: block; }
     .header .logo .tophat-logo { padding: 0; margin: 0; float: none; display: block; }
     .header .logo .logo-divider { display: none; }
     .header .logo .open-source-logo { width: 136px; height: 22px; margin: 14px 0 0; float: none; display: block; }

--- a/static/js/stars.js
+++ b/static/js/stars.js
@@ -53,10 +53,8 @@ function insertStargazerBadges(starCounts) {
         }
         const badge = document.querySelector(`.project-stars[data-project='${project}']`)
         if (badge) {
-            const projectBox = badge.parentNode
             const count = badge.querySelector('.count')
             count.innerText = item.stars
-            count.ariaLabel = `${item.stars} stars`
             badge.style.opacity = 1
         }
     })


### PR DESCRIPTION
This PR changes the layout of the project list to use `ul` instead of `div` which makes more sense to screenreaders

Also fixes a weird issue where resizing the window (make small and large again) results in the logo being misaligned. 

https://github.com/tophat/opensource.tophat.com/issues/63

DevQA:
- ✅ Site looks and behaves exactly the same
- ✅ Resizing the window doesn't result in a misaligned logo

