### PR TITLE
fix: add missing title tag in document head

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,7 @@ export const Head: React.FC = () => (
             property="og:image"
             content="https://cdn-images-1.medium.com/max/2000/1*eG2MFl0sGRKFmd_USgA_8Q.jpeg"
         />
+        <title>Top Hat Open Source Portal</title>
         <link
             rel="stylesheet"
             href="https://fonts.typotheque.com/WF-029067-010445.css"


### PR DESCRIPTION
# Description

Previous work moved away from Jekyll to use Gatsby instead (#88) but missed the `title` tag in the document heading. This leads to the published site having a raw URL as tabname. This fixes that; the text was pulled from what was in the Jekyll site.

# QA

- Generated the site via `yarn build && yarn serve`
- :heavy_check_mark: Verified that the site title is now set properly.