### PR TITLE
fix: disable legacy mode for manifest plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,6 +36,7 @@ module.exports = {
                 theme_color: '#803ed7',
                 display: 'minimal-ui',
                 icon: 'src/images/favicon/favicon-32x32.png',
+                legacy: false,
             },
         },
         'gatsby-plugin-gatsby-cloud',


### PR DESCRIPTION
# Description

Addressing #90, this restores the favicon in deployed builds.

The `gatsby-plugin-manifest` plugin seems to have a legacy mode that adds icons as `apple-touch-icon` relations in generated HTML and this doesn't seem to jive well with browsers. This probably deserves more digging, but in the meantime, disabling the legacy mode (`legacy: false` in the plugin configuration) does the trick and gets Gatsby to generate `<link rel="icon" href=... />` tags as expected.

# AuthorQA

- :heavy_check_mark: Verified that the favicon appears in local builds;
- :heavy_check_mark: Verified that the generated HTML for production builds contains favicon `link` tags with `rel="icon"` as expected;